### PR TITLE
Ts 87 Video Library

### DIFF
--- a/webpack/SearchTools.jsx
+++ b/webpack/SearchTools.jsx
@@ -1,7 +1,7 @@
 import { Loader } from '@googlemaps/js-api-loader';
 import React, { useState, useEffect, useLayoutEffect, useRef } from 'react';
 import {
-	ChakraProvider, Select, Box, Heading, Divider, Container,
+	ChakraProvider, Select, Box, Heading, Divider, Container, Flex,
 	FormControl, FormLabel, FormErrorMessage, FormHelperText,
 	Input, Slider, SliderMark, SliderTrack, SliderFilledTrack, SliderThumb
 } from '@chakra-ui/react';
@@ -20,6 +20,9 @@ const SearchTools = ({ apiKey = defaultApiKey, categories = [], makers = [] }) =
 	const [searchRadius, setSearchRadius] = useState(defaultSearchRadius);
 	const [selectedCategory, setSelectedCategory] = useState('');
 	const [userRating, setuserRating] = useState(defaultUserRating);
+	//const [videoId1, setVideoId1] = useState('');
+	//const [videoId2, setVideoId2] = useState('');
+	//const [videoId3, setVideoId3] = useState('');
 
 	const [map, setMap] = useState();
 	const mapRef = useRef();
@@ -174,7 +177,6 @@ const SearchTools = ({ apiKey = defaultApiKey, categories = [], makers = [] }) =
 	const sliderValueStyle = { textAlign: 'center', bg: 'blue.500', color: 'white', mt: '-10', ml: '-5', w: '12' };
 	const maxDist = 200;
 
-
 	return (
 		<ChakraProvider>
 			<Box className="SearchTools" w="100%" border="1px solid #E2E8F0" borderRadius="md" p={4}>
@@ -234,15 +236,23 @@ const SearchTools = ({ apiKey = defaultApiKey, categories = [], makers = [] }) =
 				<Divider my={4} />
 				<Box h={500} w='100%' className="SearchTools__Map" ref={mapRef} border="1px solid #E2E8F0" borderRadius="md" />
 				<Divider my={4} />
-				
-				<iframe src="https://www.youtube.com/embed/1kEhhP-bjks" width="560" height="315" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-
-
+				<Flex>
+				  <Box mr={10}>
+    				<iframe src={`https://www.youtube.com/embed/DuU2mnJcxPM`} width="560" height="315" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  				  </Box>
+				  <Box mr={10}>
+    				<iframe src={`https://www.youtube.com/embed/CHTHif55nSw`} width="560" height="315" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  				  </Box>
+				  <Box mr={10}>
+    				<iframe src={`https://www.youtube.com/embed/y7mz191MkT0`} width="560" height="315" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  				  </Box>
+				</Flex>
 			</Box>
 		</ChakraProvider>
 	);
 };
+
+
 
 export default SearchTools;
 

--- a/webpack/SearchTools.jsx
+++ b/webpack/SearchTools.jsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect, useLayoutEffect, useRef } from 'react';
 import {
 	ChakraProvider, Select, Box, Heading, Divider, Container, Flex,
 	FormControl, FormLabel, FormErrorMessage, FormHelperText,
+	Accordion, AccordionItem, AccordionButton, AccordionPanel,
 	Input, Slider, SliderMark, SliderTrack, SliderFilledTrack, SliderThumb
 } from '@chakra-ui/react';
 
@@ -179,79 +180,135 @@ const SearchTools = ({ apiKey = defaultApiKey, categories = [], makers = [] }) =
 
 	return (
 		<ChakraProvider>
-			<Box className="SearchTools" w="100%" border="1px solid #E2E8F0" borderRadius="md" p={4}>
-				<Container className="SearchTools__Filters" w='100%'>
-					<FormControl mb={4}>
-						<FormLabel>Search Query</FormLabel>
-						<Input placeholder='Enter search query here...'
-							value={searchQuery}
-							onChange={x => setSearchQuery(x.target.value)} />
-					</FormControl>
+		  <Box className="SearchTools" w="100%" border="1px solid #E2E8F0" borderRadius="md" p={4}>
+			<Flex className="SearchTools__Filters" w='100%' direction="row">
+			  <FormControl mb={4} mr={4}>
+				<FormLabel>Search Query</FormLabel>
+				<Input placeholder='Enter search query here...'
+				  value={searchQuery}
+				  onChange={x => setSearchQuery(x.target.value)} />
+			  </FormControl>
+	  
+			  <FormControl mb={4} mr={4}>
+				<FormLabel>Search Radius</FormLabel>
+				<Box>
+				  <Slider w='100%' defaultValue={defaultSearchRadius} max={200} onChange={x => setSearchRadius(x)}>
+					<SliderTrack>
+					  <SliderFilledTrack bg="blue.500" />
+					</SliderTrack>
+					<SliderThumb bg="blue.500" />
+					<SliderMark value={50} {...labelStyles}>50km</SliderMark>
+					<SliderMark value={100} {...labelStyles}>100km</SliderMark>
+					<SliderMark value={150} {...labelStyles}>150km</SliderMark>
+					<SliderMark value={searchRadius} {...sliderValueStyle}>{searchRadius}km</SliderMark>
+				  </Slider>
+				</Box>
+			  </FormControl>
+	  
+			  <FormControl mb={4} mr={4}>
+				<FormLabel>Tool Category</FormLabel>
+				<Select placeholder="Select category" onChange={x => setSelectedCategory(x)}>
+				  {categories.map(c => (
+					<option key={c.value} value={c.value}>
+					  {c.label}
+					</option>
+				  ))}
+				</Select>
+			  </FormControl>
+	  
+			  <FormControl mb={4}>
+				<FormLabel>User Rating</FormLabel>
+				<Box>
+				  <Slider w='100%' defaultValue={defaultUserRating} max={5} onChange={x => setuserRating(x)}>
+					<SliderTrack>
+					  <SliderFilledTrack bg="blue.500" />
+					</SliderTrack>
+					<SliderThumb bg="blue.500" />
+					<SliderMark value={1} {...labelStyles} pl={1.5}>1</SliderMark>
+					<SliderMark value={2} {...labelStyles} pl={1.5}>2</SliderMark>
+					<SliderMark value={3} {...labelStyles} pl={1.5}>3</SliderMark>
+					<SliderMark value={4} {...labelStyles} pl={1.5}>4</SliderMark>
+					<SliderMark value={5} {...labelStyles} pl={1.5}>5</SliderMark>
+					<SliderMark value={userRating} {...sliderValueStyle} w={50} ml={-6}>{userRating} Star</SliderMark>
+				  </Slider>
+				</Box>
+			  </FormControl>
+			</Flex>
+		  </Box>
+			<Divider my={4} />
+			<Box h={500} w='100%' className="SearchTools__Map" ref={mapRef} border="1px solid #E2E8F0" borderRadius="md" />
+			<Divider my={4} />
 
-					<FormControl mb={4}>
-						<FormLabel>Search Radius</FormLabel>
-						<Box>
-							<Slider w='100%' defaultValue={defaultSearchRadius} max={200} onChange={x => setSearchRadius(x)}>
-								<SliderTrack>
-									<SliderFilledTrack bg="blue.500" />
-								</SliderTrack>
-								<SliderThumb bg="blue.500" />
-								<SliderMark value={50} {...labelStyles}>50km</SliderMark>
-								<SliderMark value={100} {...labelStyles}>100km</SliderMark>
-								<SliderMark value={150} {...labelStyles}>150km</SliderMark>
-								<SliderMark value={searchRadius} {...sliderValueStyle}>{searchRadius}km</SliderMark>
-							</Slider>
-						</Box>
-					</FormControl>
-
-					<FormControl mb={4}>
-						<FormLabel>Tool Category</FormLabel>
-						<Select placeholder="Select category" onChange={x => setSelectedCategory(x)}>
-							{categories.map(c => (
-								<option key={c.value} value={c.value}>
-									{c.label}
-								</option>
-							))}
-						</Select>
-					</FormControl>
-
-					<FormControl mb={4}>
-						<FormLabel>User Rating</FormLabel>
-						<Box>
-							<Slider w='100%' defaultValue={defaultUserRating} max={5} onChange={x => setuserRating(x)}>
-								<SliderTrack>
-									<SliderFilledTrack bg="blue.500" />
-								</SliderTrack>
-								<SliderThumb bg="blue.500" />
-								<SliderMark value={1} {...labelStyles} pl={1.5}>1</SliderMark>
-								<SliderMark value={2} {...labelStyles} pl={1.5}>2</SliderMark>
-								<SliderMark value={3} {...labelStyles} pl={1.5}>3</SliderMark>
-								<SliderMark value={4} {...labelStyles} pl={1.5}>4</SliderMark>
-								<SliderMark value={5} {...labelStyles} pl={1.5}>5</SliderMark>
-								<SliderMark value={userRating} {...sliderValueStyle} w={50} ml={-6}>{userRating} Star</SliderMark>
-							</Slider>
-						</Box>
-					</FormControl>
-				</Container>
-				<Divider my={4} />
-				<Box h={500} w='100%' className="SearchTools__Map" ref={mapRef} border="1px solid #E2E8F0" borderRadius="md" />
-				<Divider my={4} />
-				<Flex>
-				  <Box mr={10}>
-    				<iframe src={`https://www.youtube.com/embed/DuU2mnJcxPM`} width="560" height="315" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-  				  </Box>
-				  <Box mr={10}>
-    				<iframe src={`https://www.youtube.com/embed/CHTHif55nSw`} width="560" height="315" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-  				  </Box>
-				  <Box mr={10}>
-    				<iframe src={`https://www.youtube.com/embed/y7mz191MkT0`} width="560" height="315" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-  				  </Box>
-				</Flex>
-			</Box>
+			
+		<Accordion allowMultiple>
+  			<AccordionItem>
+    			<AccordionButton>
+      				Video Library
+    			</AccordionButton>
+    		<AccordionPanel>
+      			<Accordion allowMultiple>
+        			<AccordionItem>
+          				<AccordionButton>
+            				Cleaning & Tool Safety
+          				</AccordionButton>
+          			<AccordionPanel>
+            		<Flex>
+              			<Box mr={75}>
+                			<iframe src={`https://www.youtube.com/embed/DuU2mnJcxPM`} width="560" height="315" title="Cleaning/Saftey Video 1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen />
+              			</Box>
+              			<Box mr={75}>
+                			<iframe src={`https://www.youtube.com/embed/CHTHif55nSw`} width="560" height="315" title="Cleaning/Saftey Video 2" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen />
+              			</Box>
+              			<Box mr={75}>
+                			<iframe src={`https://www.youtube.com/embed/y7mz191MkT0`} width="560" height="315" title="Cleaning/Saftey Video 3" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen />
+              			</Box>
+            		</Flex>
+          			</AccordionPanel>
+       				</AccordionItem>
+       	 			<AccordionItem>
+          				<AccordionButton>
+            				Picking the Right Brand For You
+          				</AccordionButton>
+          			<AccordionPanel>
+            		<Flex>
+              			<Box mr={75}>
+                			<iframe src={`https://www.youtube.com/embed/4sNsJEJS0x4`} width="560" height="315" title="Manufacturer Video 1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen />
+              			</Box>
+              			<Box mr={75}>
+                			<iframe src={`https://www.youtube.com/embed/Wr-UShXL0OA`} width="560" height="315" title="Manufacturer Video 2" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen />
+              			</Box>
+              			<Box mr={75}>
+               			 <iframe src={`https://www.youtube.com/embed/FT_qDGTwMfg`} width="560" height="315" title="Manufacturer Video 3" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen />
+              			</Box>
+            		</Flex>
+          			</AccordionPanel>
+        			</AccordionItem>
+        			<AccordionItem>
+          				<AccordionButton>
+            				Popular Tool Guides
+         				 </AccordionButton>
+          			<AccordionPanel>
+		  			<Flex>
+        				<Box mr={75}>
+          					<iframe src={`https://www.youtube.com/embed/usuXK9CL6Ns`} width="560" height="315" title="Popular Tool Video 1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen />
+        				</Box>
+        				<Box mr={75}>
+         					<iframe src={`https://www.youtube.com/embed/VXvzBPlAeDM`} width="560" height="315" title="Popular Tool Video 2" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen />
+        				</Box>
+        				<Box mr={75}>
+          					<iframe src={`https://www.youtube.com/embed/puGg_UzpVo4`} width="560" height="315" title="Popular Tool Video 3" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen />
+        				</Box>
+      				</Flex>
+          			</AccordionPanel>
+        			</AccordionItem>
+      			</Accordion>
+    		</AccordionPanel>
+  			</AccordionItem>
+		</Accordion>
+				
 		</ChakraProvider>
 	);
 };
-
 
 
 export default SearchTools;

--- a/webpack/SearchTools.jsx
+++ b/webpack/SearchTools.jsx
@@ -173,6 +173,8 @@ const SearchTools = ({ apiKey = defaultApiKey, categories = [], makers = [] }) =
 	const labelStyles = { mt: '2', ml: '-2.5', fontSize: 'sm' };
 	const sliderValueStyle = { textAlign: 'center', bg: 'blue.500', color: 'white', mt: '-10', ml: '-5', w: '12' };
 	const maxDist = 200;
+
+
 	return (
 		<ChakraProvider>
 			<Box className="SearchTools" w="100%" border="1px solid #E2E8F0" borderRadius="md" p={4}>
@@ -231,6 +233,11 @@ const SearchTools = ({ apiKey = defaultApiKey, categories = [], makers = [] }) =
 				</Container>
 				<Divider my={4} />
 				<Box h={500} w='100%' className="SearchTools__Map" ref={mapRef} border="1px solid #E2E8F0" borderRadius="md" />
+				<Divider my={4} />
+				
+				<iframe src="https://www.youtube.com/embed/1kEhhP-bjks" width="560" height="315" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+
 
 			</Box>
 		</ChakraProvider>


### PR DESCRIPTION
Relevant videos are now on the homepage under the accordion menu. I also restructured the search filters, so everything could fit on one page by default. In time for this sprint and for the future, I do not think we should add the videos associated with the tools under the map and rather just keep them on the tool details page, as this would clutter our home screen. 

## Example Output
![image](https://user-images.githubusercontent.com/45180475/230949663-7f488a98-dc3f-4bc5-b7d4-a6cb526fee10.png)
![image](https://user-images.githubusercontent.com/45180475/230949777-e9f00b6a-24f1-4982-b60f-5af4f573b95b.png)
